### PR TITLE
Non-subscriber Login Browse Issue

### DIFF
--- a/app/src/main/java/com/razeware/emitron/data/login/LoginRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/login/LoginRepository.kt
@@ -30,7 +30,9 @@ class LoginRepository @Inject constructor(
    *
    * @return True if user has permissions, otherwise False
    */
-  fun hasPermissions(): Boolean = loginPrefs.getPermissions().isNotEmpty()
+  fun hasPermissions(): Boolean {
+    return loginPrefs.getPermissions().isNotEmpty() && (!loginPrefs.getPermissions()[0].isBlank())
+  }
 
   /**
    * Store the user to preferences


### PR DESCRIPTION
Added a check on permissions to ensure not blank. This fixes an issue where non-subscribers that had logged into the app with an RW account would be taken to the Library screen after the app (i.e. MainActivity) was killed, instead of back to the login screen.