### PR TITLE
EMA #263 - Fixed a bug where the Data binding for the Pro course badge wasn't set up

### DIFF
--- a/app/src/main/res/layout/fragment_collection.xml
+++ b/app/src/main/res/layout/fragment_collection.xml
@@ -238,6 +238,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/bg_pro"
         android:text="@string/label_pro"
+        android:visibility="@{data.professional ? View.VISIBLE : View.GONE}"
         app:layout_constraintBottom_toBottomOf="@+id/text_collection_language"
         app:layout_constraintEnd_toEndOf="@+id/guideline_right"
         app:layout_constraintStart_toEndOf="@+id/text_collection_language"

--- a/model/src/main/java/com/razeware/emitron/model/Data.kt
+++ b/model/src/main/java/com/razeware/emitron/model/Data.kt
@@ -101,7 +101,7 @@ data class Data(
   fun getCardArtworkUrl(): String? = attributes?.cardArtworkUrl
 
   /**
-   *  @return true if content doesn't require subscription, else false
+   *  @return true if content requires a professional subscription, else false
    */
   fun isProfessional(): Boolean = attributes?.professional == true
 


### PR DESCRIPTION
This issue caused all courses to have the Pro course badge. This PR fixes Issue #263.

There was only one simple change, where the Data binding for the Pro course badge wasn't set up, and in turn, the view was always visible.

Because we're using Data binding, it's important to add all the attributes in the XML, as all UI logic is handled there.

To fix the issue, we had to add the missing attribute for visibility, which depends on the professional flag within Data attributes.

```xml
<androidx.appcompat.widget.AppCompatTextView
  android:id="@+id/text_collection_label_pro"
  android:visibility="@{data.professional ? View.VISIBLE : View.GONE}"
/>
```

We also updated the documentation, as it seems to have been wrongly explaining what the `isProfessional()` function returns:

```kotlin
  /**
   *  @return true if content requires a professional subscription, else false
   */
  fun isProfessional(): Boolean = attributes?.professional == true
```