### PR TITLE
Fixed a bug where view pager indicators were shown, overlapping with text

### DIFF
--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -169,7 +169,7 @@
       android:id="@+id/layout_login"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      app:constraint_referenced_ids="view_pager_login,button_sign_in"
+      app:constraint_referenced_ids="view_pager_login,button_sign_in, view_pager_indicator"
       tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Group


### PR DESCRIPTION
When the "No Subscription" state is being displayed on the LoginScreen, there was an issue where the `ViewPager` indicators were still shown (not hidden/gone) causing overlaps between it and the text.

I just added the indicators to the `layoutLogin` ConstraintGroup, forcing it to be hidden, when the "No Subscription" state is being shown.

This fixes #274.