### PR TITLE
Upgraded library-specific dependencies and versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,43 +12,43 @@ buildscript {
 
       // core
       'coreKtx'                     : "1.3.1",
-      'fragmentKtx'                 : "1.1.0",
-      'preferenceKtx'               : "1.1.0",
-      'architectureComponents'      : "2.1.0",
-      'architectureComponentsPaging': "2.1.0",
-      'workManager'                 : '2.2.0',
+      'fragmentKtx'                 : "1.2.5",
+      'preferenceKtx'               : "1.1.1",
+      'architectureComponents'      : "2.2.0",
+      'architectureComponentsPaging': "2.1.2",
+      'workManager'                 : '2.4.0',
       'annotations'                 : "1.1.0",
-      'appCompat'                   : "1.1.0",
+      'appCompat'                   : "1.2.0",
       'multidex'                    : "2.0.1",
-      'browser'                     : "1.0.0", // Chrome custom tabs
+      'browser'                     : "1.2.0", // Chrome custom tabs
 
-      'dagger'                      : '2.25.2',
-      'coroutines'                  : "1.3.3",
+      'dagger'                      : '2.27',
+      'coroutines'                  : "1.3.9",
 
       // cast
       'mediarouter'                 : "1.1.0",
       'castFramework'               : '17.1.0', // Google cast
 
       // ui
-      'constraintLayout'            : "1.1.3",
+      'constraintLayout'            : "2.0.1",
       'exoplayer'                   : "2.10.4",
-      'navigation'                  : "2.1.0",
-      'materialDesign'              : '1.1.0-beta02',
+      'navigation'                  : "2.3.0",
+      'materialDesign'              : '1.2.1',
       'vectorDrawable'              : '1.1.0',
       'recyclerView'                : "1.0.0",
       'viewpagerdots'               : "1.0.0",
       'viewpager'                   : "1.0.0",
 
       // db
-      'room'                        : '2.2.1',
+      'room'                        : '2.2.5',
 
       // time
-      'threetenabp'                 : "1.2.1",
+      'threetenabp'                 : "1.2.4",
 
       //network
-      'retrofit'                    : '2.6.2',
+      'retrofit'                    : '2.9.0',
       'moshi'                       : '1.9.2',
-      'okHttp'                      : '4.2.2',
+      'okHttp'                      : '4.8.1',
       'glide'                       : '4.10.0',
 
       //quality


### PR DESCRIPTION
Updated the rest of the libraries' versions, to match the latest.

I've had some issues with Glide, Moshi, Firebase Performance & Cast Framework dependencies.

I haven't updated them, because it seems they all have a common dependency on the Google protobuf library, so I get some duplicate classes & failed builds from Gradle, and I didn't want to dwell too long on it, so I just left them out of the updates.

This builds upon the #282 issue/ticket and on the #283 PR.