### PR TITLE
Ema 276 library pull to refresh

### DIFF
--- a/app/src/main/java/com/razeware/emitron/di/modules/NetModule.kt
+++ b/app/src/main/java/com/razeware/emitron/di/modules/NetModule.kt
@@ -55,7 +55,10 @@ class NetModule {
       authInterceptor: AuthInterceptorImpl
     ): OkHttpClient =
       OkHttpClient.Builder()
-        .connectTimeout(120, TimeUnit.SECONDS)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .callTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
         .addNetworkInterceptor(authInterceptor)
         .addInterceptor(loggingInterceptor)
         .build()

--- a/app/src/main/java/com/razeware/emitron/di/modules/NetModule.kt
+++ b/app/src/main/java/com/razeware/emitron/di/modules/NetModule.kt
@@ -55,7 +55,7 @@ class NetModule {
       authInterceptor: AuthInterceptorImpl
     ): OkHttpClient =
       OkHttpClient.Builder()
-        .connectTimeout(10, TimeUnit.SECONDS)
+        .connectTimeout(120, TimeUnit.SECONDS)
         .addNetworkInterceptor(authInterceptor)
         .addInterceptor(loggingInterceptor)
         .build()

--- a/app/src/main/java/com/razeware/emitron/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/razeware/emitron/ui/library/LibraryFragment.kt
@@ -2,12 +2,10 @@ package com.razeware.emitron.ui.library
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo.*
-import androidx.appcompat.widget.PopupMenu
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import androidx.fragment.app.activityViewModels
@@ -151,6 +149,10 @@ class LibraryFragment : DaggerFragment() {
     binding.textInputLayoutSearch.setEndIconOnClickListener {
       handleQueryCleared()
     }
+
+    binding.libraryPullToRefresh.setOnRefreshListener {
+      loadCollections()
+    }
   }
 
   private fun showRecentSearchControls() {
@@ -224,6 +226,10 @@ class LibraryFragment : DaggerFragment() {
         toggleControls(true, uiState == UiStateManager.UiState.INIT_EMPTY)
         hideRecentSearchControls()
         progressDelegate.hideProgressView()
+        binding.libraryPullToRefresh.isRefreshing = false
+      }
+      UiStateManager.UiState.INIT_FAILED -> {
+        loadCollections() // retry
       }
       else -> {
         // Handled by the adapter

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -163,24 +163,31 @@
       app:icon="@drawable/ic_material_icon_sort"
       app:iconPadding="@dimen/button_padding_internal_dense"
       app:iconTint="@color/colorIcon2"
-      app:layout_constraintBottom_toTopOf="@+id/recycler_view_library"
+      app:layout_constraintBottom_toTopOf="@+id/library_pull_to_refresh"
       app:layout_constraintEnd_toEndOf="@id/guideline_right"
       app:layout_constraintStart_toEndOf="@+id/text_library_count"
       app:layout_constraintTop_toBottomOf="@+id/scroll_view_library_filter" />
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/recycler_view_library"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+      android:id="@+id/library_pull_to_refresh"
       android:layout_width="0dp"
       android:layout_height="0dp"
       android:layout_marginTop="@dimen/activity_vertical_margin"
-      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-      app:layout_behavior="@string/appbar_scrolling_view_behavior"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="@id/guideline_right"
       app:layout_constraintStart_toStartOf="@id/guideline_left"
-      app:layout_constraintTop_toBottomOf="@+id/text_library_count"
-      tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-      tools:listitem="@layout/item_content" />
+      app:layout_constraintTop_toBottomOf="@+id/text_library_count">
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view_library"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/item_content" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <FrameLayout
       android:id="@+id/layout_progress_container"


### PR DESCRIPTION
Added a Pull to refresh component, and some logic to fix failed requests. 

Hopefully fixes #276. 

I noticed an issue with loading the Library data. For me (device & emulator), I run the app, and the Library loading progress just keeps on spinning. If I don't switch to a different fragment and back, it just never stops spinning, and never loads the data. 

Here's a video describing the behavior: https://www.dropbox.com/s/d2wz0sh86yqjcpp/continuous%20loading.webm?dl=0

I left my phone in the loading state to see if it'll work out, but after over 10 minutes of loading, nothing happened.

By adding some smaller changes such as:

```kotlin
OkHttpClient.Builder()
  .connectTimeout(30, TimeUnit.SECONDS)
  .callTimeout(30, TimeUnit.SECONDS)
  .readTimeout(30, TimeUnit.SECONDS)
  .writeTimeout(30, TimeUnit.SECONDS)
```

In the NetModule (fixes the issue), and 

```kotlin
      UiStateManager.UiState.INIT_FAILED -> {
        loadCollections() // retry
      }
```

within the LibraryFragment UI handling, I manage to add some sort of a fallback, that just loads the data continuously until the data is actually there. I also noticed we don't have proper error handling to mitigate this, so the spinner just keeps on spinning in case we don't manage to load the data properly. Not sure if this is wanted behavior @orionthewake.

@sammyd Could you check this endpoint, to see if there's something iffy with the server/api? 

Endpoint: `https://api.raywenderlich.com/api/contents?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bcontent_types%5D%5B%5D=collection&filter%5Bcontent_types%5D%5B%5D=screencast&filter%5Bq%5D=&sort=-released_at`

This is pure console output, so if you need specific data pre-formatting/encoding, let me know.

I basically realized that the request takes over 15 seconds, and the default timeout was 10ish, so adding larger timeouts should fix the issue, but I'd love it if we could see if we could optimize the request somehow.

--

The behavior regarding the Pull To Request feature is shown below in the video:

Pull To Refresh: https://www.dropbox.com/s/mg9huokv5tcndbv/pull%20to%20refresh.webm?dl=0

It kind of falls out of place regarding our design system, as it's just a regular PTR, but I think it's a good fallback for folks that wanted this feature. Let me know if we'd like to apply more design to this, or change it up somehow!

--

I do have some concerns regarding our current loading process, and the way data is being handled/propagated throughout the app, I think it may be a bit too complex for the simplicity of what it does (loads 1-2 requests and that's it), so I'd love to see if I can try to optimize this or clean up the code a bit in the future. But also, it works fine, so I guess "if it ain't broke, don't fix it"? @orionthewake Would love to hear your thoughts.