### PR TITLE
Added window inset handling, sorted out the SettingsFragment scrolling behavior

### DIFF
--- a/app/src/main/java/com/razeware/emitron/MainActivity.kt
+++ b/app/src/main/java/com/razeware/emitron/MainActivity.kt
@@ -9,6 +9,8 @@ import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.view.doOnLayout
+import androidx.core.view.updatePadding
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -75,6 +77,34 @@ class MainActivity : DaggerAppCompatActivity() {
     initObservers()
     CastContext.getSharedInstance(this)
     initPendingDownloadsWorker()
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      setupWindowInsets()
+    }
+  }
+
+  /**
+   * Because new devices often use display cutouts (A.K.A. Notches), to save up screen real estate
+   * for front cameras, it's important to add extra padding to the top part of the screen, to avoid
+   * notch overlapping with the UI.
+   *
+   * To do this, we read the Notch size, and reduce the number by the default status bar height,
+   * because this is the margin size that's added to all the screens by default. This provides us
+   * with a stable UI, that doesn't overlap any content with the notch.
+   * */
+  @TargetApi(Build.VERSION_CODES.P)
+  private fun setupWindowInsets() {
+    binding.container.doOnLayout {
+      val inset = binding.container.rootWindowInsets
+
+      val cutoutSize = inset?.stableInsetTop
+
+      if (cutoutSize != null) {
+        val defaultTopMargin = resources.getDimensionPixelSize(R.dimen.guideline_top_status_bar)
+
+        binding.container.updatePadding(top = cutoutSize - defaultTopMargin)
+      }
+    }
   }
 
   private fun createNotificationChannels() {

--- a/app/src/main/java/com/razeware/emitron/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/razeware/emitron/ui/settings/SettingsFragment.kt
@@ -164,9 +164,9 @@ class SettingsFragment : DaggerFragment() {
       titleVersionName.text = getString(
         R.string.label_version, BuildConfig.VERSION_NAME
       )
-			titleLoggedInUser.text = getString(
-				R.string.settings_logged_in_user, viewModel.getLoggedInUser()
-			)
+      titleLoggedInUser.text = getString(
+        R.string.settings_logged_in_user, viewModel.getLoggedInUser()
+      )
       switchCrashReporting.setOnCheckedChangeListener { _, checked ->
         viewModel.updateCrashReportingAllowed(checked)
       }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -11,6 +11,16 @@
     android:orientation="vertical"
     app:paddingBottomSystemWindowInsets="@{true}">
 
+    <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_marginTop="@dimen/guideline_top_status_bar_1"
+      android:layout_height="?android:actionBarSize"
+      app:layout_constraintBottom_toTopOf="@+id/title_version_name"
+      app:layout_constraintTop_toTopOf="@+id/guideline_top"
+      app:layout_constraintVertical_bias="0"
+      app:layout_constraintVertical_chainStyle="packed" />
+
     <ScrollView
       android:layout_width="match_parent"
       android:layout_height="0dp"
@@ -21,14 +31,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clipToPadding="true">
-
-
-        <androidx.constraintlayout.widget.Guideline
-          android:id="@+id/guideline_top"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:orientation="horizontal"
-          app:layout_constraintGuide_begin="@dimen/guideline_top_status_bar_1" />
 
         <androidx.constraintlayout.widget.Guideline
           android:id="@+id/guideline_left"
@@ -51,15 +53,6 @@
           android:orientation="horizontal"
           app:layout_constraintGuide_end="@dimen/guideline_bottom_gesture" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-          android:id="@+id/toolbar"
-          android:layout_width="match_parent"
-          android:layout_height="?android:actionBarSize"
-          app:layout_constraintBottom_toTopOf="@+id/title_version_name"
-          app:layout_constraintTop_toTopOf="@+id/guideline_top"
-          app:layout_constraintVertical_bias="0"
-          app:layout_constraintVertical_chainStyle="packed" />
-
         <androidx.appcompat.widget.AppCompatTextView
           android:id="@+id/title_video_quality"
           style="@style/TextAppearance.Body.1"
@@ -70,7 +63,7 @@
           app:layout_constraintBottom_toTopOf="@+id/divider_0"
           app:layout_constraintEnd_toStartOf="@id/settings_selected_video_quality"
           app:layout_constraintStart_toStartOf="@id/guideline_left"
-          app:layout_constraintTop_toBottomOf="@id/toolbar" />
+          app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.appcompat.widget.AppCompatTextView
           android:id="@+id/settings_selected_video_quality"
@@ -480,41 +473,41 @@
 
     </ScrollView>
 
-		<LinearLayout
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:orientation="vertical">
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
 
-			<androidx.appcompat.widget.AppCompatTextView
-				android:id="@+id/title_logged_in_user"
-				style="@style/TextAppearance.Body.1"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:gravity="center_vertical"
-				android:layout_marginTop="@dimen/text_spacing_vertical_default"
-				android:layout_marginBottom="@dimen/text_spacing_vertical_default"
-				app:layout_constraintEnd_toStartOf="@id/guideline_right"
-				app:layout_constraintStart_toStartOf="@id/guideline_left"
-				app:layout_constraintTop_toBottomOf="@+id/divider_10"
-				android:layout_gravity="center"
-				tools:text="Logged in as lukusfreebird" />
+      <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/title_logged_in_user"
+        style="@style/TextAppearance.Body.1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="@dimen/text_spacing_vertical_default"
+        android:layout_marginBottom="@dimen/text_spacing_vertical_default"
+        android:gravity="center_vertical"
+        app:layout_constraintEnd_toStartOf="@id/guideline_right"
+        app:layout_constraintStart_toStartOf="@id/guideline_left"
+        app:layout_constraintTop_toBottomOf="@+id/divider_10"
+        tools:text="Logged in as lukusfreebird" />
 
-			<com.google.android.material.button.MaterialButton
-				android:id="@+id/button_logout"
-				style="@style/Button.Colored.3.Icon"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:layout_gravity="bottom"
-				android:layout_marginBottom="@dimen/activity_vertical_margin"
-				android:layout_marginStart="@dimen/activity_vertical_margin"
-				android:layout_marginEnd="@dimen/activity_vertical_margin"
-				android:text="@string/button_sign_out"
-				app:icon="@drawable/ic_material_button_icon_arrow_right_red_contained"
-				app:iconGravity="end"
-				app:iconTint="@color/white"
-				app:iconTintMode="multiply"
-				tools:visibility="visible" />
+      <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_logout"
+        style="@style/Button.Colored.3.Icon"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="@dimen/activity_vertical_margin"
+        android:layout_marginEnd="@dimen/activity_vertical_margin"
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:text="@string/button_sign_out"
+        app:icon="@drawable/ic_material_button_icon_arrow_right_red_contained"
+        app:iconGravity="end"
+        app:iconTint="@color/white"
+        app:iconTintMode="multiply"
+        tools:visibility="visible" />
 
-		</LinearLayout>
+    </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/values-v28/styles.xml
+++ b/app/src/main/res/values-v28/styles.xml
@@ -12,6 +12,7 @@
     <item name="colorPrimarySurface">@color/colorBackground</item>
     <item name="materialCardViewStyle">@style/Card</item>
     <item name="materialAlertDialogTheme">@style/AlertDialog</item>
+    <item name="android:windowLayoutInDisplayCutoutMode">default</item>
   </style>
 
   <style name="AppTheme.Toolbar_Overlay" parent="AppTheme">

--- a/app/src/main/res/values-v29/styles.xml
+++ b/app/src/main/res/values-v29/styles.xml
@@ -12,6 +12,7 @@
     <item name="colorPrimarySurface">@color/colorBackground</item>
     <item name="materialCardViewStyle">@style/Card</item>
     <item name="materialAlertDialogTheme">@style/AlertDialog</item>
+    <item name="android:windowLayoutInDisplayCutoutMode">default</item>
   </style>
 
   <style name="AppTheme.Popup" parent="Widget.AppCompat.PopupMenu">


### PR DESCRIPTION
Fixed #281.

I added programmatic handling of Notches/Window insets to increase the top content padding, depending on the inset size. Now there is no more overlap with notches and the content.

I also changed up the layout in the Settings Fragment. It didn't make sense to me that the Toolbar and the back button were scrollable. I think it makes more sense to be fixed, as on smaller phones the user will scroll away the back button, and have to scroll back to go back (if they don't have SW/HW back buttons).

I'll add some images to show the behavior/changes.