### PR TITLE
Ema-289 library screen performance - DO NOT MERGE

### DIFF
--- a/app/src/main/java/com/razeware/emitron/data/bookmarks/BookmarkBoundaryCallback.kt
+++ b/app/src/main/java/com/razeware/emitron/data/bookmarks/BookmarkBoundaryCallback.kt
@@ -1,7 +1,7 @@
 package com.razeware.emitron.data.bookmarks
 
 import androidx.paging.PagedList
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.Data
 import com.razeware.emitron.model.DataType
 import com.razeware.emitron.utils.*

--- a/app/src/main/java/com/razeware/emitron/data/bookmarks/BookmarkRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/bookmarks/BookmarkRepository.kt
@@ -4,7 +4,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import androidx.paging.PagedList
 import androidx.paging.toLiveData
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.Content
 import com.razeware.emitron.model.Data
 import com.razeware.emitron.utils.BoundaryCallbackNotifier

--- a/app/src/main/java/com/razeware/emitron/data/content/ContentRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/content/ContentRepository.kt
@@ -5,6 +5,9 @@ import androidx.annotation.MainThread
 import androidx.lifecycle.Transformations
 import androidx.paging.PagedList
 import androidx.paging.toLiveData
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
+import com.razeware.emitron.data.content.remote.ContentApi
+import com.razeware.emitron.data.content.remote.ContentDataSourceFactoryRemote
 import com.razeware.emitron.data.settings.SettingsPrefs
 import com.razeware.emitron.model.Content
 import com.razeware.emitron.model.Contents
@@ -43,7 +46,8 @@ class ContentRepository @Inject constructor(
       pageSize,
       api,
       threadManager,
-      filters
+      filters,
+      contentDataSourceLocal
     )
 
     val pagedListConfig = PagedList.Config.Builder()

--- a/app/src/main/java/com/razeware/emitron/data/content/dao/ContentDao.kt
+++ b/app/src/main/java/com/razeware/emitron/data/content/dao/ContentDao.kt
@@ -21,7 +21,15 @@ interface ContentDao {
    * Get observer for contents
    */
   @Query("SELECT * FROM contents")
-  fun getContents(): LiveData<List<Content>>
+  fun getContentsObserver(): LiveData<List<Content>>
+
+  /**
+   * Get observer for contents
+   */
+  @Query(
+    "SELECT * FROM contents WHERE contents.content_type in(:allowedContentTypes)"
+  )
+  fun getContents(allowedContentTypes: Array<String>): List<Content>
 
   /**
    * Insert contents

--- a/app/src/main/java/com/razeware/emitron/data/content/local/ContentDataSourceLocal.kt
+++ b/app/src/main/java/com/razeware/emitron/data/content/local/ContentDataSourceLocal.kt
@@ -1,4 +1,4 @@
-package com.razeware.emitron.data.content
+package com.razeware.emitron.data.content.local
 
 import androidx.lifecycle.LiveData
 import androidx.paging.DataSource
@@ -10,6 +10,7 @@ import com.razeware.emitron.model.ContentType
 import com.razeware.emitron.model.Data
 import com.razeware.emitron.model.DataType
 import com.razeware.emitron.model.entity.*
+import org.threeten.bp.OffsetDateTime
 import javax.inject.Inject
 
 /**
@@ -102,9 +103,23 @@ class ContentDataSourceLocal @Inject constructor(
   }
 
   /**
-   * Get observer for contents table
+   * Get observer for contents table.
    */
-  fun getContents(): LiveData<List<Content>> = contentDao.getContents()
+  fun getContentsObserver(): LiveData<List<Content>> = contentDao.getContentsObserver()
+
+  /**
+   * Synchronous way to load data, without using an observer.
+   * */
+  fun getContentsData(allowedContentTypes: Array<String>): List<Data> {
+    val cachedContents = contentDao.getContents(allowedContentTypes)
+
+    return cachedContents.map { it.toData() }.sortedByDescending {
+      val date = OffsetDateTime.parse(it.getReleasedAt())
+
+      date.toEpochSecond()
+    }
+  }
+
 
   /**
    * Get a content (screencast/video-course)

--- a/app/src/main/java/com/razeware/emitron/data/content/remote/ContentApi.kt
+++ b/app/src/main/java/com/razeware/emitron/data/content/remote/ContentApi.kt
@@ -1,4 +1,4 @@
-package com.razeware.emitron.data.content
+package com.razeware.emitron.data.content.remote
 
 import com.razeware.emitron.model.Content
 import com.razeware.emitron.model.Contents

--- a/app/src/main/java/com/razeware/emitron/data/content/remote/ContentDataSourceFactoryRemote.kt
+++ b/app/src/main/java/com/razeware/emitron/data/content/remote/ContentDataSourceFactoryRemote.kt
@@ -1,7 +1,8 @@
-package com.razeware.emitron.data.content
+package com.razeware.emitron.data.content.remote
 
 import androidx.lifecycle.MutableLiveData
 import androidx.paging.DataSource
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.Data
 import com.razeware.emitron.utils.async.ThreadManager
 
@@ -12,7 +13,8 @@ class ContentDataSourceFactoryRemote(
   private val pageSize: Int,
   private val contentApi: ContentApi,
   private val threadManager: ThreadManager,
-  private val filters: List<Data>
+  private val filters: List<Data>,
+  private val contentDataSourceLocal: ContentDataSourceLocal
 ) : DataSource.Factory<Int, Data>() {
 
   /**
@@ -25,7 +27,7 @@ class ContentDataSourceFactoryRemote(
    */
   override fun create(): DataSource<Int, Data> {
     val source = ContentDataSourceRemote(
-      pageSize, contentApi, threadManager, filters
+      pageSize, contentApi, contentDataSourceLocal, threadManager, filters
     )
     sourceLiveData.postValue(source)
     return source

--- a/app/src/main/java/com/razeware/emitron/data/download/DownloadRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/download/DownloadRepository.kt
@@ -6,7 +6,7 @@ import androidx.annotation.WorkerThread
 import androidx.lifecycle.LiveData
 import androidx.paging.PagedList
 import androidx.paging.toLiveData
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.*
 import com.razeware.emitron.model.entity.Download
 import com.razeware.emitron.model.entity.DownloadWithContent

--- a/app/src/main/java/com/razeware/emitron/data/progressions/ProgressionBoundaryCallback.kt
+++ b/app/src/main/java/com/razeware/emitron/data/progressions/ProgressionBoundaryCallback.kt
@@ -1,7 +1,7 @@
 package com.razeware.emitron.data.progressions
 
 import androidx.paging.PagedList
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.CompletionStatus
 import com.razeware.emitron.model.Data
 import com.razeware.emitron.model.DataType

--- a/app/src/main/java/com/razeware/emitron/data/progressions/ProgressionRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/progressions/ProgressionRepository.kt
@@ -4,7 +4,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import androidx.paging.PagedList
 import androidx.paging.toLiveData
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.*
 import com.razeware.emitron.model.entity.Progression
 import com.razeware.emitron.model.entity.WatchStat

--- a/app/src/main/java/com/razeware/emitron/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/settings/SettingsRepository.kt
@@ -1,7 +1,7 @@
 package com.razeware.emitron.data.settings
 
 import androidx.annotation.WorkerThread
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.data.login.LoginPrefs
 import com.razeware.emitron.data.progressions.ProgressionDataSourceLocal
 import com.razeware.emitron.ui.onboarding.OnboardingView
@@ -14,7 +14,7 @@ import javax.inject.Inject
  */
 class SettingsRepository @Inject constructor(
   private val threadManager: ThreadManager,
-	private val loginPrefs: LoginPrefs,
+  private val loginPrefs: LoginPrefs,
   private val settingsPrefs: SettingsPrefs,
   private val contentDataSourceLocal: ContentDataSourceLocal,
   private val progressionDataSourceLocal: ProgressionDataSourceLocal

--- a/app/src/main/java/com/razeware/emitron/di/modules/NetModule.kt
+++ b/app/src/main/java/com/razeware/emitron/di/modules/NetModule.kt
@@ -2,7 +2,7 @@ package com.razeware.emitron.di.modules
 
 import com.razeware.emitron.BuildConfig
 import com.razeware.emitron.data.bookmarks.BookmarkApi
-import com.razeware.emitron.data.content.ContentApi
+import com.razeware.emitron.data.content.remote.ContentApi
 import com.razeware.emitron.data.download.DownloadApi
 import com.razeware.emitron.data.filter.FilterApi
 import com.razeware.emitron.data.login.LoginApi

--- a/app/src/main/java/com/razeware/emitron/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/razeware/emitron/ui/library/LibraryFragment.kt
@@ -222,14 +222,16 @@ class LibraryFragment : DaggerFragment() {
         progressDelegate.showProgressView()
         toggleControls()
       }
-      UiStateManager.UiState.INIT_LOADED, UiStateManager.UiState.INIT_EMPTY -> {
+      UiStateManager.UiState.INIT_LOADED,
+      UiStateManager.UiState.INIT_EMPTY,
+      UiStateManager.UiState.INIT_FAILED -> {
         toggleControls(true, uiState == UiStateManager.UiState.INIT_EMPTY)
         hideRecentSearchControls()
         progressDelegate.hideProgressView()
         binding.libraryPullToRefresh.isRefreshing = false
       }
-      UiStateManager.UiState.INIT_FAILED -> {
-        loadCollections() // retry
+      UiStateManager.UiState.ERROR_CONNECTION -> {
+        binding.libraryPullToRefresh.isRefreshing = false
       }
       else -> {
         // Handled by the adapter
@@ -238,7 +240,7 @@ class LibraryFragment : DaggerFragment() {
   }
 
   private fun loadCollections() {
-    if (isNetNotConnected()) {
+    if (isNetNotConnected() && false) {
       pagedFragment.value.onErrorConnection()
       progressDelegate.hideProgressView()
       showNoInternetUI()

--- a/app/src/test/java/com/razeware/emitron/data/bookmarks/BookmarkRepositoryTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/bookmarks/BookmarkRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.razeware.emitron.data.bookmarks
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
 import com.nhaarman.mockitokotlin2.*
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.*
 import com.razeware.emitron.utils.TestCoroutineRule
 import com.razeware.emitron.utils.async.ThreadManager

--- a/app/src/test/java/com/razeware/emitron/data/content/ContentDataSourceLocalTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/content/ContentDataSourceLocalTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.*
 import com.razeware.emitron.data.content.dao.*
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.data.filter.dao.CategoryDao
 import com.razeware.emitron.data.filter.dao.DomainDao
 import com.razeware.emitron.data.progressions.dao.ProgressionDao
@@ -483,10 +484,10 @@ class ContentDataSourceLocalTest {
     val contents = MutableLiveData<List<com.razeware.emitron.model.entity.Content>>().apply {
       value = listOf(content)
     }
-    whenever(contentDataSourceLocal.getContents()).doReturn(contents)
+    whenever(contentDataSourceLocal.getContentsObserver()).doReturn(contents)
 
     val result =
-      contentDataSourceLocal.getContents().observeForTestingResultNullable()
+      contentDataSourceLocal.getContentsObserver().observeForTestingResultNullable()
     result isEqualTo listOf(content)
   }
 

--- a/app/src/test/java/com/razeware/emitron/data/content/ContentRepositoryTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/content/ContentRepositoryTest.kt
@@ -3,6 +3,8 @@ package com.razeware.emitron.data.content
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.*
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
+import com.razeware.emitron.data.content.remote.ContentApi
 import com.razeware.emitron.data.settings.SettingsPrefs
 import com.razeware.emitron.model.*
 import com.razeware.emitron.utils.*

--- a/app/src/test/java/com/razeware/emitron/data/download/DownloadRepositoryTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/download/DownloadRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.razeware.emitron.data.download
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.*
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.data.createContent
 import com.razeware.emitron.model.*
 import com.razeware.emitron.model.entity.Download

--- a/app/src/test/java/com/razeware/emitron/data/progressions/ProgressionRepositoryTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/progressions/ProgressionRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.razeware.emitron.data.progressions
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
 import com.nhaarman.mockitokotlin2.*
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.model.Content
 import com.razeware.emitron.model.Contents
 import com.razeware.emitron.model.Data

--- a/app/src/test/java/com/razeware/emitron/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/settings/SettingsRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.razeware.emitron.data.settings
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.*
-import com.razeware.emitron.data.content.ContentDataSourceLocal
+import com.razeware.emitron.data.content.local.ContentDataSourceLocal
 import com.razeware.emitron.data.login.LoginPrefs
 import com.razeware.emitron.data.progressions.ProgressionDataSourceLocal
 import com.razeware.emitron.ui.onboarding.OnboardingView


### PR DESCRIPTION
This is a placeholder PR, to show some progress on the library screen performance issue.

@orionthewake I've done some research and some progress on the #289.

The current data flow implementation is extremely complicated and a bit too tightly coupled. Instead of having reusable and clean way to differentiate different types of data fetching, the paging library is just deeply rooted at the data fetching, meaning it's not just easily refactored and changed to be database-first/offline-first.

I think, if we want to support full-on offline mode, we'd have to refactor a good amount of the application and the data flow, to somehow integrate database data instead of using the remote API as its primary source of information.

Also, all the adapters are using the same `ContentAdapter`, meaning that we could technically use this heavy coupling & system of data loading, and somehow try to switch from the remote source to a local source.

That being said, I think a good estimate on this could be to spend a few weeks, instead of a week, to fully refactor all parts of the app to try to cache data locally before showing it.

I feel like I'd also like to refactor the UI parts and how the uiState handling is done, as that part seems also very convoluted and hard to work around/with.

I've attached a few screenshots of the behavior on this branch. The process is the following:
- Every first page is being cached in the DB. 
- In case there's a load error or a network error, the DB data is shown.
- In case there is no DB data, an empty view/error view is shown.
- Once data is loaded, the Network data is shown.

The issues with current data loading is the following:

- Paging only allows us to `loadInitial()`, `loadAfter()` and `loadBefore()`. This means we can load the initial page, and then move up or down (load after or before the initial page) in terms of data.

The problem here is that we store _all the content_ in the same way. Well it's all content, and all within the `Contents` table. So things like bookmarks, progressions, collections, etc. are all in the same table.

That being said, in case we want to switch to an `offline-first` model, we'd have to decide how this is going to behave. How many items will we store, what happens when the user connects to the app - do we clear the DB and start loading and storing new items etc.

There are many use cases we'd have to think about and develop/test because small things can mess up the paging setup and the DB contents.

In an ideal (and much simplified use case), we'd just connect our data to a LiveData from the DB and then as we scroll we'd load more and more items from the network. That way the data would just update automatically.

But as it sits, the data comes from a paging source and we'd have to refactor a good amount of code that's used all over the place.

- We also don't have any placeholders for images. If the images don't load, we just don't show them. This can be fixed by forcing image loads/caching and then having more data stored offline (and would be awesome for offline-first modes).

**We can discuss this more in our meeting** but I feel like we'd have to do a bigger overhaul of the app soon to make things easier in the future!

![Screenshot_20201019-122039](https://user-images.githubusercontent.com/17215808/96444888-5aac9000-120f-11eb-9a42-066c94511637.png)
![Screenshot_20201019-121920](https://user-images.githubusercontent.com/17215808/96444903-5d0eea00-120f-11eb-8f1c-095edaf8efd9.png)
![Screenshot_20201019-122048](https://user-images.githubusercontent.com/17215808/96444910-6009da80-120f-11eb-9d7e-46766859ffcf.png)
![Screenshot_20201019-122000](https://user-images.githubusercontent.com/17215808/96444921-639d6180-120f-11eb-8fbf-4876b573e707.png)
![Screenshot_20201019-122008](https://user-images.githubusercontent.com/17215808/96444923-6435f800-120f-11eb-9668-69e88082fb4c.png)

These images show how the offline first behavior currently works. There is _some data_ cached, but not all of it. I'd love to have this one of the bigger features we build in the next few months or something!
