### PR TITLE
v1.0.9: Donald 🦆

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
 
   // Architecture components
-  implementation "androidx.lifecycle:lifecycle-runtime:${versions.architectureComponents}"
+  implementation "androidx.lifecycle:lifecycle-runtime-ktx:${versions.architectureComponents}"
   implementation "androidx.lifecycle:lifecycle-common-java8:${versions.architectureComponents}"
   implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.architectureComponents}"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
 
   // Architecture components
-  implementation "androidx.lifecycle:lifecycle-runtime-ktx:${versions.architectureComponents}"
+  implementation "androidx.lifecycle:lifecycle-runtime:${versions.architectureComponents}"
   implementation "androidx.lifecycle:lifecycle-common-java8:${versions.architectureComponents}"
   implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.architectureComponents}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
       'minSdk'                      : 21,
       'targetSdk'                   : 30,
       'compileSdk'                  : 30,
-      'gradle'                      : '4.1.0',
+      'gradle'                      : '4.0.1',
       'kotlin'                      : '1.4.10',
 
       // core

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
       'kotlin'                      : '1.4.10',
 
       // core
-      'coreKtx'                     : "1.3.2",
+      'coreKtx'                     : "1.3.1",
       'fragmentKtx'                 : "1.2.5",
       'preferenceKtx'               : "1.1.1",
       'architectureComponents'      : "2.2.0",
@@ -22,7 +22,7 @@ buildscript {
       'multidex'                    : "2.0.1",
       'browser'                     : "1.2.0", // Chrome custom tabs
 
-      'dagger'                      : '2.28.3',
+      'dagger'                      : '2.27',
       'coroutines'                  : "1.3.9",
 
       // cast
@@ -30,9 +30,9 @@ buildscript {
       'castFramework'               : '17.1.0', // Google cast
 
       // ui
-      'constraintLayout'            : "2.0.2",
+      'constraintLayout'            : "2.0.1",
       'exoplayer'                   : "2.10.4",
-      'navigation'                  : "2.3.1",
+      'navigation'                  : "2.3.0",
       'materialDesign'              : '1.2.1',
       'vectorDrawable'              : '1.1.0',
       'recyclerView'                : "1.0.0",

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
       'kotlin'                      : '1.4.10',
 
       // core
-      'coreKtx'                     : "1.3.1",
+      'coreKtx'                     : "1.3.2",
       'fragmentKtx'                 : "1.2.5",
       'preferenceKtx'               : "1.1.1",
       'architectureComponents'      : "2.2.0",
@@ -22,7 +22,7 @@ buildscript {
       'multidex'                    : "2.0.1",
       'browser'                     : "1.2.0", // Chrome custom tabs
 
-      'dagger'                      : '2.27',
+      'dagger'                      : '2.28.3',
       'coroutines'                  : "1.3.9",
 
       // cast
@@ -30,9 +30,9 @@ buildscript {
       'castFramework'               : '17.1.0', // Google cast
 
       // ui
-      'constraintLayout'            : "2.0.1",
+      'constraintLayout'            : "2.0.2",
       'exoplayer'                   : "2.10.4",
-      'navigation'                  : "2.3.0",
+      'navigation'                  : "2.3.1",
       'materialDesign'              : '1.2.1',
       'vectorDrawable'              : '1.1.0',
       'recyclerView'                : "1.0.0",

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 buildscript {
   ext.versions = [
       // build
-      'versionCode'                 : 23,
-      'versionName'                 : "1.0.8",
+      'versionCode'                 : 24,
+      'versionName'                 : "1.0.9",
       'minSdk'                      : 21,
       'targetSdk'                   : 30,
       'compileSdk'                  : 30,

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Reverts the Gradle version and Android Gradle Plugin version in order to address a minification issue that was causing a crash when trying to show a Snackbar in production builds. See #295 

Will need to hold off on upgrading Gradle and the AGP until this issue is addressed in Proguard/R8 and/or the Material Components library:

https://github.com/material-components/material-components-android/issues/1814

