### PR TITLE
Added checks to see if there is an Activity to handle the intent

### DIFF
--- a/inappreview/src/main/java/com/raywenderlich/android/inappreview/manager/InAppReviewManagerImpl.kt
+++ b/inappreview/src/main/java/com/raywenderlich/android/inappreview/manager/InAppReviewManagerImpl.kt
@@ -72,7 +72,7 @@ class InAppReviewManagerImpl @Inject constructor(
    * @param activity - The Activity to which the lifecycle is attached.
    * */
   override fun startReview(activity: Activity) {
-    if (reviewInfo != null && false) {
+    if (reviewInfo != null) {
       reviewManager.launchReviewFlow(activity, reviewInfo).addOnCompleteListener { reviewFlow ->
         onReviewFlowLaunchCompleted(reviewFlow)
       }
@@ -92,25 +92,26 @@ class InAppReviewManagerImpl @Inject constructor(
   private fun sendUserToPlayStore() {
     val appPackageName = context.packageName
 
-    try {
-      val sendIntent = Intent(
-        Intent.ACTION_VIEW,
-        Uri.parse("market://details?id=$appPackageName")
-      ).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+    val sendIntent = Intent(
+      Intent.ACTION_VIEW,
+      Uri.parse("market://details?id=$appPackageName")
+    ).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
 
-      if (sendIntent.resolveActivity(context.packageManager) != null) {
-        context.startActivity(sendIntent)
-      }
+    if (sendIntent.resolveActivity(context.packageManager) != null) {
+      context.startActivity(sendIntent)
+    } else {
+      sendUserToWeb(appPackageName)
+    }
+  }
 
-    } catch (error: Error) {
-      val sendIntent = Intent(
-        Intent.ACTION_VIEW,
-        Uri.parse("https://play.google.com/store/apps/details?id=$appPackageName")
-      ).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+  private fun sendUserToWeb(appPackageName: String) {
+    val sendIntent = Intent(
+      Intent.ACTION_VIEW,
+      Uri.parse("https://play.google.com/store/apps/details?id=$appPackageName")
+    ).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
 
-      if (sendIntent.resolveActivity(context.packageManager) != null) {
-        context.startActivity(sendIntent)
-      }
+    if (sendIntent.resolveActivity(context.packageManager) != null) {
+      context.startActivity(sendIntent)
     }
   }
 

--- a/inappreview/src/main/java/com/raywenderlich/android/inappreview/manager/InAppReviewManagerImpl.kt
+++ b/inappreview/src/main/java/com/raywenderlich/android/inappreview/manager/InAppReviewManagerImpl.kt
@@ -72,7 +72,7 @@ class InAppReviewManagerImpl @Inject constructor(
    * @param activity - The Activity to which the lifecycle is attached.
    * */
   override fun startReview(activity: Activity) {
-    if (reviewInfo != null) {
+    if (reviewInfo != null && false) {
       reviewManager.launchReviewFlow(activity, reviewInfo).addOnCompleteListener { reviewFlow ->
         onReviewFlowLaunchCompleted(reviewFlow)
       }
@@ -93,19 +93,24 @@ class InAppReviewManagerImpl @Inject constructor(
     val appPackageName = context.packageName
 
     try {
-      context.startActivity(
-        Intent(
-          Intent.ACTION_VIEW,
-          Uri.parse("market://details?id=$appPackageName")
-        )
-      )
+      val sendIntent = Intent(
+        Intent.ACTION_VIEW,
+        Uri.parse("market://details?id=$appPackageName")
+      ).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+
+      if (sendIntent.resolveActivity(context.packageManager) != null) {
+        context.startActivity(sendIntent)
+      }
+
     } catch (error: Error) {
-      context.startActivity(
-        Intent(
-          Intent.ACTION_VIEW,
-          Uri.parse("https://play.google.com/store/apps/details?id=$appPackageName")
-        )
-      )
+      val sendIntent = Intent(
+        Intent.ACTION_VIEW,
+        Uri.parse("https://play.google.com/store/apps/details?id=$appPackageName")
+      ).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+
+      if (sendIntent.resolveActivity(context.packageManager) != null) {
+        context.startActivity(sendIntent)
+      }
     }
   }
 


### PR DESCRIPTION
Also added the flag to be able to start activities outside of another Activity (using App context)

Fixes #324. 

Basically added more checks to make sure the app doesn't crash if the device doesn't have a browser or the Play Store (which shouldn't happen).

Also added a flag to start things in a new task, as required by the SDK.