### PR TITLE
fix: Link personal permissions with login repository

### DIFF
--- a/app/src/main/java/com/razeware/emitron/data/login/LoginRepository.kt
+++ b/app/src/main/java/com/razeware/emitron/data/login/LoginRepository.kt
@@ -117,6 +117,6 @@ class LoginRepository @Inject constructor(
    * Check if user has Team Videos permission
    */
 
-   fun isStreamTeamsVideosPlayback():Boolean =
+   fun isTeamsVideosPlayback():Boolean =
      loginPrefs.getPermissions().contains(PermissionTag.StreamTeams.param)
 }

--- a/app/src/main/java/com/razeware/emitron/ui/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/razeware/emitron/ui/collection/CollectionViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.exoplayer2.offline.Download
 import com.raywenderlich.android.inappreview.InAppReviewView
 import com.razeware.emitron.data.content.ContentRepository
+import com.razeware.emitron.data.login.LoginRepository
 import com.razeware.emitron.model.Content
 import com.razeware.emitron.model.ContentType
 import com.razeware.emitron.model.Data
@@ -38,6 +39,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CollectionViewModel @Inject constructor(
   private val repository: ContentRepository,
+  private val loginRepository: LoginRepository,
   private val bookmarkActionDelegate: BookmarkActionDelegate,
   private val progressionActionDelegate: ProgressionActionDelegate,
   private val downloadActionDelegate: DownloadActionDelegate,
@@ -310,34 +312,27 @@ class CollectionViewModel @Inject constructor(
   ): Boolean {
     val collection = _collection.value
     val isCollectionFree = collection?.attributes?.free ?: false
-    val isProfessionalContent = collection?.isProfessional()
-    val isPersonalContent = collection?.isPersonal()
-    val isTeamsContent = collection?.isTeams()
+    val isPersonalContent = loginRepository.isPersonalVideosPlayback()
+    val isTeamsContent = loginRepository.isTeamsVideosPlayback()
     val isDownloaded = collection?.isDownloaded()
 
     return when {
-      isConnected && isProfessionalContent == true -> {
-        if (checkDownloadPermission && isDownloaded == true) {
-          permissionActionDelegate.isDownloadAllowed()
-        } else {
-          permissionActionDelegate.isProfessionalVideoPlaybackAllowed()
-        }
-      }
-
-      isConnected && isPersonalContent == true ->{
-        if (checkDownloadPermission && isDownloaded()){
+      isConnected && isPersonalContent -> {
+        if (checkDownloadPermission && isDownloaded == true){
           permissionActionDelegate.isDownloadAllowed()
         }else{
           permissionActionDelegate.isPersonalVideosPlaybackAllowed()
         }
       }
-      isConnected && isTeamsContent == true ->{
-        if (checkDownloadPermission && isDownloaded()){
+
+      isConnected && isTeamsContent -> {
+        if (checkDownloadPermission && isDownloaded == true){
           permissionActionDelegate.isDownloadAllowed()
         }else{
-          permissionActionDelegate.isSteamTeamsVideoPlaybackAllowed()
+          permissionActionDelegate.isTeamsVideoPlaybackAllowed()
         }
       }
+
       !isConnected -> permissionActionDelegate.isDownloadAllowed()
       else -> {
         if (checkDownloadPermission && isDownloaded == true) {

--- a/app/src/main/java/com/razeware/emitron/ui/login/PermissionActionDelegate.kt
+++ b/app/src/main/java/com/razeware/emitron/ui/login/PermissionActionDelegate.kt
@@ -41,7 +41,7 @@ interface PermissionsAction {
   /**
    * @return true if teams videos can be played, else false
    */
-  fun isSteamTeamsVideoPlaybackAllowed():Boolean
+  fun isTeamsVideoPlaybackAllowed():Boolean
 
   /**
    * LiveData for permission action
@@ -134,6 +134,6 @@ class PermissionActionDelegate @Inject constructor(
   override fun isPersonalVideosPlaybackAllowed(): Boolean =
     loginRepository.isPersonalVideosPlayback()
 
-  override fun isSteamTeamsVideoPlaybackAllowed(): Boolean =
-    loginRepository.isStreamTeamsVideosPlayback()
+  override fun isTeamsVideoPlaybackAllowed(): Boolean =
+    loginRepository.isTeamsVideosPlayback()
 }

--- a/app/src/test/java/com/razeware/emitron/data/login/LoginRepositoryTest.kt
+++ b/app/src/test/java/com/razeware/emitron/data/login/LoginRepositoryTest.kt
@@ -125,7 +125,7 @@ class LoginRepositoryTest {
   fun hasTeamsPermission(){
     whenever(loginPrefs.getPermissions()).doReturn(listOf("stream-team-videos"))
 
-    repository.isStreamTeamsVideosPlayback() isEqualTo true
+    repository.isTeamsVideosPlayback() isEqualTo true
   }
 
   @Test

--- a/app/src/test/java/com/razeware/emitron/ui/collection/CollectionViewModelTest.kt
+++ b/app/src/test/java/com/razeware/emitron/ui/collection/CollectionViewModelTest.kt
@@ -52,6 +52,7 @@ class CollectionViewModelTest {
     viewModel =
       CollectionViewModel(
         contentRepository,
+        loginRepository,
         bookmarkActionDelegate,
         progressionActionDelegate,
         downloadActionDelegate,

--- a/app/src/test/java/com/razeware/emitron/ui/collection/CollectionViewModelTest.kt
+++ b/app/src/test/java/com/razeware/emitron/ui/collection/CollectionViewModelTest.kt
@@ -815,7 +815,7 @@ class CollectionViewModelTest {
       val content = createContent(data = contentData)
       whenever(contentRepository.getContent("1")).doReturn(content)
       viewModel.loadCollection(Data(id = "1"))
-      whenever(permissionActionDelegate.isProfessionalVideoPlaybackAllowed()).doReturn(true)
+      whenever(permissionActionDelegate.isPersonalVideosPlaybackAllowed()).doReturn(true)
 
       // When
       val result = viewModel.isContentPlaybackAllowed(true)

--- a/app/src/test/java/com/razeware/emitron/ui/collection/CollectionViewModelTest.kt
+++ b/app/src/test/java/com/razeware/emitron/ui/collection/CollectionViewModelTest.kt
@@ -803,7 +803,7 @@ class CollectionViewModelTest {
   }
 
   @Test
-  fun isContentPlaybackAllowed_Professional_isConnected() {
+  fun isContentPlaybackAllowed_Pro_Personal_isConnected() {
     createViewModel()
     testCoroutineRule.runBlockingTest {
       // Given
@@ -815,6 +815,7 @@ class CollectionViewModelTest {
       val content = createContent(data = contentData)
       whenever(contentRepository.getContent("1")).doReturn(content)
       viewModel.loadCollection(Data(id = "1"))
+      whenever(loginRepository.isPersonalVideosPlayback()).doReturn(true)
       whenever(permissionActionDelegate.isPersonalVideosPlaybackAllowed()).doReturn(true)
 
       // When
@@ -824,6 +825,30 @@ class CollectionViewModelTest {
       result isEqualTo true
     }
   }
+
+  // NOTE: Basic subscription free
+  @Test
+  fun isContentPlaybackAllowed_Pro_Basic_isConnected() {
+    createViewModel()
+    testCoroutineRule.runBlockingTest {
+      // Given
+      val contentData = createContentData(
+        type = "screencast",
+        groups = null,
+        professional = true
+      )
+      val content = createContent(data = contentData)
+      whenever(contentRepository.getContent("1")).doReturn(content)
+      viewModel.loadCollection(Data(id = "1"))
+      // When
+      val result = viewModel.isContentPlaybackAllowed(true)
+
+      permissionActionDelegate.isPersonalVideosPlaybackAllowed() isEqualTo false
+      // Then
+      result isEqualTo false
+    }
+  }
+
 
   @Test
   fun isContentPlaybackAllowed_isConnected_isDownloaded() {

--- a/model/src/main/java/com/razeware/emitron/model/Attributes.kt
+++ b/model/src/main/java/com/razeware/emitron/model/Attributes.kt
@@ -74,16 +74,6 @@ data class Attributes(
   val professional: Boolean? = null,
 
   /**
-   * Is content free?
-   */
-  val teams:Boolean? = null,
-
-  /**
-   * Is content free?
-   */
-  val personal:Boolean?= null,
-
-  /**
    * Content popularity
    */
   val popularity: Double? = null,

--- a/model/src/main/java/com/razeware/emitron/model/Data.kt
+++ b/model/src/main/java/com/razeware/emitron/model/Data.kt
@@ -106,14 +106,6 @@ data class Data(
   fun isProfessional(): Boolean = attributes?.professional == true
 
   /**
-   *  @return true if content requires a personal subscription, else false
-   */
-  fun isPersonal(): Boolean = attributes?.personal == true
-
-
-  fun isTeams(): Boolean = attributes?.teams == true
-
-  /**
    *  If data represents a progression object
    *
    *  @return percent completion value for progression

--- a/model/src/main/java/com/razeware/emitron/model/PermissionTag.kt
+++ b/model/src/main/java/com/razeware/emitron/model/PermissionTag.kt
@@ -20,16 +20,12 @@ enum class PermissionTag(val param: String) {
   /**
    * For Teams
    */
-
   StreamTeams("stream-team-videos"),
 
   /**
    * Personal Videos
    */
-
   StreamPersonal("stream-personal-videos");
-
-
 
   companion object {
     /**


### PR DESCRIPTION
- Removed personal and team attribute
- Removed professional content check as personal is added to all
  - For personal subscribers, this previous condition was being true for pro contents, however `isProfessionalVideoPlaybackAllowed()` was false and thus the content gets locked and returns before reaching the personal check
  - The existing personal and team values will always be false as they are not present and should be fetched from permissions. 
- Fixed typo

Fixes #352 